### PR TITLE
Coordinate update from Integer to Double

### DIFF
--- a/src/main/java/br/unb/cic/pistar/model/BasicEntity.java
+++ b/src/main/java/br/unb/cic/pistar/model/BasicEntity.java
@@ -3,8 +3,8 @@ package br.unb.cic.pistar.model;
 public abstract class BasicEntity extends BaseEntity {
 
     private String text;
-    private Integer x;
-    private Integer y;
+    private Double x;
+    private Double y;
 
     public String getText() {
         return text;
@@ -14,19 +14,19 @@ public abstract class BasicEntity extends BaseEntity {
         this.text = text;
     }
 
-    public Integer getX() {
+    public Double getX() {
         return x;
     }
 
-    public void setX(Integer x) {
+    public void setX(Double x) {
         this.x = x;
     }
 
-    public Integer getY() {
+    public Double getY() {
         return y;
     }
 
-    public void setY(Integer y) {
+    public void setY(Double y) {
         this.y = y;
     }
 }


### PR DESCRIPTION
O erro se dava ao tentar serializar valores em ponto flutuante para valores inteiros. Foi necessário só mudar o tipo do atributo  que o problema foi resolvido.